### PR TITLE
Renamed ReleaseState to ReleaseRepository

### DIFF
--- a/cli/deploy_production
+++ b/cli/deploy_production
@@ -3,7 +3,7 @@
 
 use Symfony\Component\Process\Process;
 use WMDE\Fundraising\Deployment\Deployer;
-use WMDE\Fundraising\Deployment\PDOReleaseState;
+use WMDE\Fundraising\Deployment\PdoReleaseRepository;
 
 require_once __DIR__ . '../vendor/autoload.php';
 
@@ -17,7 +17,7 @@ if ( !file_exists( DB_DSN ) ) {
 
 $cwd = empty( $argv[1] ) ? null : $argv[1];
 
-$releaseState = new PDOReleaseState( new \PDO( DB_DSN ), BRANCH_NAME );
+$releaseState = new PdoReleaseRepository( new \PDO( DB_DSN ), BRANCH_NAME );
 $deployer = new Deployer( $releaseState  );
 $command = new Process( DEPLOY_COMMAND, $cwd );
 $deployer->run( $command );

--- a/cli/deploy_test
+++ b/cli/deploy_test
@@ -3,7 +3,7 @@
 
 use Symfony\Component\Process\Process;
 use WMDE\Fundraising\Deployment\Deployer;
-use WMDE\Fundraising\Deployment\PDOReleaseState;
+use WMDE\Fundraising\Deployment\PdoReleaseRepository;
 
 require_once __DIR__ . '../vendor/autoload.php';
 
@@ -17,7 +17,7 @@ if ( !file_exists( DB_DSN ) ) {
 
 $cwd = empty( $argv[1] ) ? null : $argv[1];
 
-$releaseState = new PDOReleaseState( new \PDO( DB_DSN ), BRANCH_NAME );
+$releaseState = new PdoReleaseRepository( new \PDO( DB_DSN ), BRANCH_NAME );
 $deployer = new Deployer( $releaseState  );
 $command = new Process( DEPLOY_COMMAND, $cwd );
 $deployer->run( $command );

--- a/src/Deployer.php
+++ b/src/Deployer.php
@@ -13,7 +13,7 @@ class Deployer {
 
 	private $releaseState;
 
-	public function __construct( ReleaseState $releaseState ) {
+	public function __construct( ReleaseRepository $releaseState ) {
 		$this->releaseState = $releaseState;
 	}
 

--- a/src/PdoReleaseRepository.php
+++ b/src/PdoReleaseRepository.php
@@ -8,7 +8,7 @@ namespace WMDE\Fundraising\Deployment;
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
-class PDOReleaseState implements ReleaseState {
+class PdoReleaseRepository implements ReleaseRepository {
 
 	private $db;
 	private $branchName;

--- a/src/ReleaseRepository.php
+++ b/src/ReleaseRepository.php
@@ -6,7 +6,7 @@ namespace WMDE\Fundraising\Deployment;
  * @license GNU GPL v2+
  * @author Gabriel Birke < gabriel.birke@wikimedia.de >
  */
-interface ReleaseState {
+interface ReleaseRepository {
 
 	public function hasUndeployedReleases(): bool;
 

--- a/test/DeployerTest.php
+++ b/test/DeployerTest.php
@@ -3,7 +3,7 @@
 namespace WMDE\Fundraising\Deployment\Tests;
 
 use WMDE\Fundraising\Deployment\Deployer;
-use WMDE\Fundraising\Deployment\ReleaseState;
+use WMDE\Fundraising\Deployment\ReleaseRepository;
 use Symfony\Component\Process\Process;
 
 class DeployerTest extends \PHPUnit_Framework_TestCase {
@@ -11,7 +11,7 @@ class DeployerTest extends \PHPUnit_Framework_TestCase {
 	const RELEASE_ID = 'deadbeef';
 
 	public function testGivenNoReleases_deployCommandIsNotCalled() {
-		$releaseState = $this->createMock( ReleaseState::class );
+		$releaseState = $this->createMock( ReleaseRepository::class );
 		$releaseState->method( 'hasUndeployedReleases' )->willReturn( false );
 
 		$command = $this->createMock( Process::class );
@@ -34,7 +34,7 @@ class DeployerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenReleaseInDeployment_deployCommandIsNotCalled() {
-		$releaseState = $this->createMock( ReleaseState::class );
+		$releaseState = $this->createMock( ReleaseRepository::class );
 		$releaseState->method( 'hasUndeployedReleases' )->willReturn( true );
 		$releaseState->method( 'deploymentInProcess' )->willReturn( true );
 
@@ -77,10 +77,10 @@ class DeployerTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @return ReleaseState|\PHPUnit_Framework_MockObject_MockObject
+	 * @return ReleaseRepository|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private function createDeployableReleaseState() {
-		$releaseState = $this->createMock( ReleaseState::class );
+		$releaseState = $this->createMock( ReleaseRepository::class );
 		$releaseState->method( 'hasUndeployedReleases' )->willReturn( true );
 		$releaseState->method( 'deploymentInProcess' )->willReturn( false );
 		$releaseState->method( 'getLatestReleaseId' )->willReturn( self::RELEASE_ID );

--- a/test/PdoReleaseRepositoryTest.php
+++ b/test/PdoReleaseRepositoryTest.php
@@ -2,10 +2,10 @@
 
 namespace WMDE\Fundraising\Deployment\Tests;
 
-use WMDE\Fundraising\Deployment\PDOReleaseState;
+use WMDE\Fundraising\Deployment\PdoReleaseRepository;
 use WMDE\Fundraising\Deployment\ReleaseStateWriter;
 
-class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
+class PdoReleaseRepositoryTest extends \PHPUnit_Framework_TestCase {
 	
 	const BRANCH_NAME = 'testBranch';
 	const FIRST_RELEASE = 'deadbeef';
@@ -35,33 +35,33 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testGivenNewRelaseState_itHasNoUndeployedReleases() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->assertFalse( $releaseState->hasUndeployedReleases() );
 	}
 
 	public function testWhenAddingARelease_itIsUndeployed() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->insertFirstRelease();
 
 		$this->assertTrue( $releaseState->hasUndeployedReleases() );
 	}
 
 	public function testWhenAddingARelease_deploymentInProcessReturnsFalse() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->insertFirstRelease();
 
 		$this->assertFalse( $releaseState->deploymentInProcess() );
 	}
 
 	public function testGivenSeveralReleases_getLatestReleasesReturnsTheMostRecent() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->insertThreeReleases();
 
 		$this->assertEquals( self::THIRD_RELEASE, $releaseState->getLatestReleaseId() );
 	}
 
 	public function testWhenAReleaseIsMarkedForDeployment_deploymentInProcessReturnsTrue() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->insertFirstRelease();
 
 		$releaseState->markDeploymentAsStarted( self::FIRST_RELEASE );
@@ -69,7 +69,7 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenAddingAndDeployingARelease_itIsNotUndeployed() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME );
 		$this->insertFirstRelease();
 		$releaseState->markDeploymentAsStarted( self::FIRST_RELEASE );
 
@@ -77,7 +77,7 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenEndingADeployment_deploymentInProcessReturnsFalse() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME  );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME  );
 		$this->insertFirstRelease();
 		$releaseState->markDeploymentAsStarted( self::FIRST_RELEASE );
 		$releaseState->markDeploymentAsFinished( self::FIRST_RELEASE );
@@ -87,7 +87,7 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenEndingADeployment_previousUndeployedReleasesAreMarkedAsEnded() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME  );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME  );
 		$this->insertThreeReleases();
 		$releaseState->markDeploymentAsStarted( self::THIRD_RELEASE );
 		$releaseState->markDeploymentAsFinished( self::THIRD_RELEASE );
@@ -97,7 +97,7 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenEndingADeployment_subsequentReleasesAreNotTouched() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME  );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME  );
 		$this->insertThreeReleases();
 		$releaseState->markDeploymentAsStarted( self::SECOND_RELEASE );
 		$releaseState->markDeploymentAsFinished( self::SECOND_RELEASE );
@@ -108,7 +108,7 @@ class PDOReleaseStateTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function testWhenMarkingADeploymentAsFailed_ItCanBeDeployedAgain() {
-		$releaseState = new PDOReleaseState( $this->db, self::BRANCH_NAME  );
+		$releaseState = new PdoReleaseRepository( $this->db, self::BRANCH_NAME  );
 		$this->insertFirstRelease();
 		$releaseState->markDeploymentAsStarted( self::FIRST_RELEASE );
 		$releaseState->markDeploymentAsFailed( self::FIRST_RELEASE );


### PR DESCRIPTION
To me, the name "release state" suggests some kind of value object
that holds the state of a single release.
