### PR TITLE
Added onDeploymentFailed callback to Deployer

### DIFF
--- a/test/EdgeToEdge/WebRouteTestCase.php
+++ b/test/EdgeToEdge/WebRouteTestCase.php
@@ -10,7 +10,6 @@ use Symfony\Component\HttpKernel\Client;
 
 /**
  * @licence GNU GPL v2+
- * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class WebRouteTestCase extends \PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
This is so that the stuff constructing the Deployer can specify
what should happen when a deployment fails. Part of
https://phabricator.wikimedia.org/T123049
